### PR TITLE
changed-terminal-trucation

### DIFF
--- a/airootfs/root/.config/starship.toml
+++ b/airootfs/root/.config/starship.toml
@@ -45,7 +45,7 @@ $time\
 style = "fg:#180024 bg:#7E6B9C  "
 format = "[ $path ]($style)"
 truncation_length = 3
-truncation_symbol = "…/"
+truncation_symbol = "../"
 
 [directory.substitutions]
 "Documents" = " "


### PR DESCRIPTION
## Title :  Wrong path shown in terminal

## Issue no : #114 

## Description
- There is a issue, where the path is shown as `../.documents`

## Screenshots (if applicable)
![IMG_6141](https://github.com/tcet-opensource/tcet-linux/assets/92705023/43d26ace-efd3-454b-8be8-dea108fe5f52)


## Checklist
- [X] I have read and agree to abide by the [Code of Conduct](https://github.com/tcet-opensource/.github/blob/main/CODE_OF_CONDUCT.md)
- [X] I have read and followed the **Contributing Guidelines**